### PR TITLE
🔧 Update deployment helm chart for multi images

### DIFF
--- a/public-fullstack-app/Chart.yaml
+++ b/public-fullstack-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/public-fullstack-app/templates/deployment.yaml
+++ b/public-fullstack-app/templates/deployment.yaml
@@ -14,27 +14,28 @@ spec:
         version: "{{ .Values.application.version }}"
     spec:
       containers:
-        - name: {{- template "app.service" . }}
-          image: {{ .Values.application.image }}
-          imagePullPolicy: Always
+        {{ range .Values.application.containers }}
+        - name: {{ .name }}
+          image: {{ .image }}
+          imagePullPolicy: {{ .pullPolicy | default "Always" }}
           ports:
-            - containerPort: {{ .Values.application.port }}
-              name: app-port
-          {{ if or .Values.application.environment .Values.application.secrets }}
+            - containerPort: {{ .port }}
+              name: {{ .name }}-port
+          {{ if .environment or .secrets }}
           envFrom:
-            {{ if .Values.application.environment }}
+            {{ if .environment }}
             - configMapRef:
-                name: {{- template "app.service" . }}
+                name: {{ .name }}
             {{ end }}
-            {{ if .Values.application.secrets }}
+            {{ if .secrets }}
             - secretRef:
-                name: {{- template "app.service" . }}
+                name: {{ .name }}
             {{ end }}
           {{ end }}
-          {{ if .Values.application.volume }}
+          {{ if volume }}
           volumeMounts:
-            - name: {{- template "app.service" . }}
-              mountPath: {{ .Values.application.volume.mountPath }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
           {{ end }}
       {{ if .Values.application.volume }}
       volumes:


### PR DESCRIPTION
Updating the deployment helm chart to support multiple containers and images by utilising a range map.