### PR TITLE
Update helm chart for multi volume support

### DIFF
--- a/public-fullstack-app/templates/deployment.yaml
+++ b/public-fullstack-app/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
           ports:
             - containerPort: {{ .port }}
               name: {{ .name }}-port
-          {{- if .environment or .secrets }}
+          {{- if or .environment .secrets }}
           envFrom:
             {{- if .environment }}
             - configMapRef:
@@ -33,18 +33,22 @@ spec:
                 name: {{ .name }}
             {{- end }}
           {{- end }}
-          {{- if .Values.application.volume }}
+          {{- if .volumeMounts }}
           volumeMounts:
-            - name: {{- template "app.service" . }}
-              mountPath: {{ .Values.application.volume.mountPath }}
+            {{- range .volumeMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
           {{- end }}
         {{- end }}
         {{- end }}
-      {{- if .Values.application.volume }}
+      {{- if .Values.application.volumes }}
       volumes:
-        - name: {{- template "app.service" . }}
+        {{- range .Values.application.volumes }}
+        - name: {{ .name }}
           persistentVolumeClaim:
-            claimName: {{- template "app.service" . }}
+            claimName: {{ .name }}
+        {{- end }}
       {{- end }}
       imagePullSecrets:
         - name: regcred

--- a/public-fullstack-app/templates/env-configmap.yaml
+++ b/public-fullstack-app/templates/env-configmap.yaml
@@ -1,7 +1,12 @@
-{{ if .Values.application.environment }}
+{{- if .Values.application.containers }}
+{{- range .Values.application.containers }}
+{{- if .environment }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{- template "app.service" . }}
-data: {{ .Values.application.environment | toYaml | nindent 2 }}
-{{ end }}
+  name: {{ .name }}
+data: {{ .environment | toYaml | nindent 2 }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/public-fullstack-app/templates/env-secret.yaml
+++ b/public-fullstack-app/templates/env-secret.yaml
@@ -1,8 +1,13 @@
-{{ if .Values.application.secrets }}
+{{- if .Values.application.containers }}
+{{- range .Values.application.containers }}
+{{- if .secrets }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{- template "app.service" . }}
+  name: {{ .name }}
 type: Opaque
-stringData: {{ .Values.application.secrets | toYaml | nindent 2 }}
-{{ end }}
+stringData: {{ .secrets | toYaml | nindent 2 }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/public-fullstack-app/templates/volume.yaml
+++ b/public-fullstack-app/templates/volume.yaml
@@ -1,13 +1,16 @@
-{{ if .Values.application.volume }}
+{{- if .Values.application.volumes }}
+{{- range .Values.application.volumes }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{- template "app.service" . }}
+  name: {{ .name }}
 spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: local-path
   resources:
     requests:
-      storage: {{ .Values.application.volume.size }}
-{{ end }}
+      storage: {{ .size }}
+---
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Updating public fullstack app's helm chart to support multiple volumes and multiple volume mounts in each container.

This PR also addresses the lack of a range map over the configMap and secret templates, which are now required as each container will require their own configurations.