### PR TITLE
Hard code port name to avoid length issue

### DIFF
--- a/public-fullstack-app/templates/deployment.yaml
+++ b/public-fullstack-app/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
           imagePullPolicy: {{ .pullPolicy | default "Always" }}
           ports:
             - containerPort: {{ .port }}
-              name: {{ .name }}-port
+              name: app-port
           {{- if or .environment .secrets }}
           envFrom:
             {{- if .environment }}


### PR DESCRIPTION
The name of the container port is limited at 15 characters, and since the port names need only be unique within all named ports of a given container, we don't need to worry about uniqueness as in its current config, there will not be more than one port per container.