### PR TITLE
🐛 Allow apps with 0 ingresses

### DIFF
--- a/charts/generic-app/CHANGELOG.md
+++ b/charts/generic-app/CHANGELOG.md
@@ -1,0 +1,10 @@
+## `generic-app` chart
+
+Version 0.1.1
+
+- Number of containers with ingress annotations can now be 0 or 1, as it should be to allow for services
+  that don't need ingress.
+
+Version 0.1.0
+
+- Initial release

--- a/charts/generic-app/Chart.yaml
+++ b/charts/generic-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/generic-app/templates/deployment.yaml
+++ b/charts/generic-app/templates/deployment.yaml
@@ -5,8 +5,8 @@
     {{- $exposedContainers = add $exposedContainers 1 }}
   {{- end }}
 {{- end }}
-{{- if ne $exposedContainers 1 }}
-  {{- fail "Error: One container and one container only should have an ingress defined" }}
+{{- if gt $exposedContainers 1 }}
+  {{- fail "Error: Only one container at max should have an ingress defined" }}
 {{- end }}
 
 {{- range .Values.deployments }}


### PR DESCRIPTION
Fixing the check to allow for apps with 0 or 1 ingresses to be deployed. Also added a basic changelog to the chart to keep track of changes.