### PR TITLE
🧱 Minor changes to `generic-app`

### DIFF
--- a/charts/generic-app/CHANGELOG.md
+++ b/charts/generic-app/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## `generic-app` chart
 
+Version 0.1.2
+
+- Add support for multiple containers with ingress annotations.
+- Add support for `subPath` in config file mounts, to allow mounting individual files to existing directories.
+- `targetPort` will now default to use `port` if `targetPort` is not defined, else it will use `80`.
+- `ingress` will now use `letsencrypt-prod` issuer by default
+
 Version 0.1.1
 
 - Number of containers with ingress annotations can now be 0 or 1, as it should be to allow for services

--- a/charts/generic-app/Chart.yaml
+++ b/charts/generic-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/generic-app/templates/deployment.yaml
+++ b/charts/generic-app/templates/deployment.yaml
@@ -1,14 +1,3 @@
-# Ensure that only one container has an ingress
-{{- $exposedContainers := 0 -}}
-{{- range .Values.deployments }}
-  {{- if .ingress }}
-    {{- $exposedContainers = add $exposedContainers 1 }}
-  {{- end }}
-{{- end }}
-{{- if gt $exposedContainers 1 }}
-  {{- fail "Error: Only one container at max should have an ingress defined" }}
-{{- end }}
-
 {{- range .Values.deployments }}
 apiVersion: apps/v1
 kind: Deployment
@@ -84,6 +73,7 @@ spec:
             {{- if .config }}
             - name: config-file-{{ .name }}
               mountPath: {{ .config.mountPath | default "/config" }}
+              subPath: {{ .config.subPath | default "" }}
               readOnly: true
             {{- end }}
             {{- if .secrets }}

--- a/charts/generic-app/templates/ingress.yaml
+++ b/charts/generic-app/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ template "app.namespace" $ | default "default" }}
   annotations:
     traefik.ingress.kubernetes.io/router.tls: "true"
-    cert-manager.io/cluster-issuer: "letsencrypt-{{ $.Values.environment }}"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
 
 spec:
   ingressClassName: traefik

--- a/charts/generic-app/templates/service.yaml
+++ b/charts/generic-app/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .service.type | default "ClusterIP" }}
   ports:
     - port: {{ .service.port | default 80 }}
-      targetPort: {{ .service.targetPort | default 80 }}
+      targetPort: {{ .service.targetPort | default .service.port | default 80 }}
       protocol: {{ .service.protocol | default "TCP" }}
   selector:
     app: {{ .name }}

--- a/charts/generic-app/templates/statefulset.yaml
+++ b/charts/generic-app/templates/statefulset.yaml
@@ -70,6 +70,7 @@ spec:
             {{- if .config }}
             - name: config-file-{{ .name }}
               mountPath: {{ .config.mountPath | default "/config" }}
+              subPath: {{ .config.subPath | default "" }}
               readOnly: true
             {{- end }}
             {{- if .secrets }}

--- a/charts/generic-app/values.schema.json
+++ b/charts/generic-app/values.schema.json
@@ -34,6 +34,14 @@
                 ],
                 "required": [],
                 "type": "string"
+              },
+              "subPath": {
+                "description": "Subpath inside the volume to mount the configuration file. This can be used in conjunction with mountPath to mount a file to an existing folder inside the volume. In this case, the subPath should be the name of the file, and the mountPath should be the full path to the file including the file.\n",
+                "examples": [
+                  "config.yaml"
+                ],
+                "required": [],
+                "type": "string"
               }
             },
             "required": [
@@ -316,7 +324,7 @@
                 "type": "string"
               },
               "targetPort": {
-                "description": "Port to expose on the container. This should be the port the application itself is listening on.",
+                "description": "Port to expose on the container. This should be the port the application itself is listening on. If not specified, it will default to the port specified in the service.port field.\n",
                 "examples": [
                   "80"
                 ],
@@ -445,6 +453,14 @@
                 "description": "Path inside the container where the configuration file will be mounted.",
                 "examples": [
                   "/config"
+                ],
+                "required": [],
+                "type": "string"
+              },
+              "subPath": {
+                "description": "Subpath inside the volume to mount the configuration file. This can be used in conjunction with mountPath to mount a file to an existing folder inside the volume. In this case, the subPath should be the name of the file, and the mountPath should be the full path to the file including the file.\n",
+                "examples": [
+                  "config.yaml"
                 ],
                 "required": [],
                 "type": "string"
@@ -663,7 +679,7 @@
                 "type": "string"
               },
               "targetPort": {
-                "description": "Port to expose on the container. This should be the port the application itself is listening on.",
+                "description": "Port to expose on the container. This should be the port the application itself is listening on. If not specified, it will default to the port specified in the service.port field.\n",
                 "examples": [
                   "80"
                 ],

--- a/charts/generic-app/values.yaml
+++ b/charts/generic-app/values.yaml
@@ -70,7 +70,9 @@ version: "not set"
 #           examples: [80]
 #         targetPort:
 #           type: integer
-#           description: Port to expose on the container. This should be the port the application itself is listening on.
+#           description: >
+#             Port to expose on the container. This should be the port the application itself is listening on. If not
+#             specified, it will default to the port specified in the service.port field.
 #           examples: [80]
 #         protocol:
 #           type: string
@@ -218,6 +220,13 @@ version: "not set"
 #           type: string
 #           description: Path inside the container where the configuration file will be mounted.
 #           examples: [/config]
+#         subPath:
+#           type: string
+#           description: >
+#             Subpath inside the volume to mount the configuration file. This can be used in conjunction with
+#             mountPath to mount a file to an existing folder inside the volume. In this case, the subPath
+#             should be the name of the file, and the mountPath should be the full path to the file including the file.
+#           examples: [config.yaml]
 #     secrets:
 #       type: object
 #       additionalProperties: true
@@ -322,7 +331,9 @@ deployments: []
 #           examples: [80]
 #         targetPort:
 #           type: integer
-#           description: Port to expose on the container. This should be the port the application itself is listening on.
+#           description: >
+#             Port to expose on the container. This should be the port the application itself is listening on. If not
+#             specified, it will default to the port specified in the service.port field.
 #           examples: [80]
 #         protocol:
 #           type: string
@@ -432,6 +443,13 @@ deployments: []
 #           type: string
 #           description: Path inside the container where the configuration file will be mounted.
 #           examples: [/config]
+#         subPath:
+#           type: string
+#           description: >
+#             Subpath inside the volume to mount the configuration file. This can be used in conjunction with
+#             mountPath to mount a file to an existing folder inside the volume. In this case, the subPath
+#             should be the name of the file, and the mountPath should be the full path to the file including the file.
+#           examples: [config.yaml]
 #     secrets:
 #       type: object
 #       additionalProperties: true


### PR DESCRIPTION
Minor changes to `generic-app` to further support deployment of MOCBOT services.

- Add support for multiple containers with ingress annotations.
- Add support for `subPath` in config file mounts to allow mounting individual files to existing directories.
- `targetPort` will now default to use `port` if `targetPort` is not defined, else it will use `80`.
- `ingress` will now use `letsencrypt-prod` issuer by default.