### PR TITLE
🔧 Add support for no subdomain

### DIFF
--- a/charts/generic-app/CHANGELOG.md
+++ b/charts/generic-app/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## `generic-app` chart
 
+Version 0.1.3
+
+- Add support for no subdomain being provided, which will just use the base domain.
+
 Version 0.1.2
 
 - Add support for multiple containers with ingress annotations.

--- a/charts/generic-app/templates/ingress.yaml
+++ b/charts/generic-app/templates/ingress.yaml
@@ -12,10 +12,10 @@ metadata:
 spec:
   ingressClassName: traefik
   tls:
-    - hosts: ["{{ $d.ingress.subdomain }}.masterofcubesau.com"]
+    - hosts: ["{{ if $d.ingress.subdomain }}{{ $d.ingress.subdomain }}.{{ end }}masterofcubesau.com"]
       secretName: {{ template "app.service" $ }}-tls
   rules:
-    - host: "{{ $d.ingress.subdomain }}.masterofcubesau.com"
+    - host: "{{ if $d.ingress.subdomain }}{{ $d.ingress.subdomain }}.{{ end }}masterofcubesau.com"
       http:
         paths:
           - path: {{ $d.ingress.urlPrefix | default "/" }}

--- a/charts/generic-app/values.schema.json
+++ b/charts/generic-app/values.schema.json
@@ -84,9 +84,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "subdomain"
-            ],
+            "required": [],
             "type": "object"
           },
           "initContainer": {

--- a/charts/generic-app/values.yaml
+++ b/charts/generic-app/values.yaml
@@ -82,7 +82,6 @@ version: "not set"
 #     ingress:
 #       type: object
 #       additionalProperties: false
-#       required: [subdomain]
 #       description: >
 #         Configuration for the Ingress to expose the container.
 #         This is used to expose the container to the outside world.


### PR DESCRIPTION
Adding support for no subdomain being provided, which will simply use the base domain instead.